### PR TITLE
Berezkin.Task3

### DIFF
--- a/project/Task3/cache.py
+++ b/project/Task3/cache.py
@@ -1,0 +1,69 @@
+from typing import Callable, Any, Dict, Optional
+from functools import wraps
+import inspect
+
+def cache(maxsize: Optional[int] = None) -> Callable:
+    """
+    Caches the results of a function.
+    
+    Stores the results of function calls with different arguments.
+ 
+    Arguments:
+    maxsize: How many results to store. If None, the cache is disabled.
+ 
+    Returns:
+    A function with caching.
+
+    ValueError: if the cache is full
+    """
+    def decorator(func: Callable) -> Callable:
+        if maxsize is None:
+            return func
+        
+        # Привдим нехэшируемые типы объектов к хэшируемым
+        def to_hashable(obj: Any) -> Any:
+                """We use recursion to make elements like [1, 2, [3, 4]] work correctly"""
+                if isinstance(obj, (int, float, str, bytes, bool, type(None))):
+                    return obj
+                elif isinstance(obj, (list, tuple)):
+                    return tuple(to_hashable(item) for item in obj)
+                elif isinstance(obj, dict):
+                    return tuple(sorted((k, to_hashable(v)) for k, v in obj.items()))
+                elif isinstance(obj, set):
+                    return tuple(sorted(to_hashable(item) for item in obj))
+                else:
+                    try:
+                        hash(obj)
+                        return obj
+                    except TypeError:
+                        # for other non-hashable objects, use repr to convert them to a string
+                        return repr(obj)
+        
+        cache_dict: Dict[Any, Any] = {}
+        
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            sig = inspect.signature(func)
+            bound_args = sig.bind(*args, **kwargs)
+            bound_args.apply_defaults()
+            
+            hashable_args = to_hashable(bound_args.args)
+            hashable_kwargs = to_hashable(bound_args.kwargs)
+
+            cache_key = (func.__name__, hashable_args, hashable_kwargs)
+
+            if cache_key in cache_dict:
+                return cache_dict[cache_key]
+            
+            if len(cache_dict) == maxsize:
+               raise ValueError(f"Cache full: {maxsize} items max")
+            
+            result = func(*args, **kwargs)
+            cache_dict[cache_key] = result
+            return result
+        
+        setattr(wrapper, 'cache_dict', cache_dict)
+        
+        return wrapper
+    
+    return decorator

--- a/project/Task3/cache.py
+++ b/project/Task3/cache.py
@@ -2,51 +2,53 @@ from typing import Callable, Any, Dict, Optional
 from functools import wraps
 import inspect
 
+
 def cache(maxsize: Optional[int] = None) -> Callable:
     """
     Caches the results of a function.
-    
+
     Stores the results of function calls with different arguments.
- 
+
     Arguments:
     maxsize: How many results to store. If None, the cache is disabled.
- 
+
     Returns:
     A function with caching.
 
     ValueError: if the cache is full
     """
+
     def decorator(func: Callable) -> Callable:
         if maxsize is None:
             return func
-        
+
         # Привдим нехэшируемые типы объектов к хэшируемым
         def to_hashable(obj: Any) -> Any:
-                """We use recursion to make elements like [1, 2, [3, 4]] work correctly"""
-                if isinstance(obj, (int, float, str, bytes, bool, type(None))):
+            """We use recursion to make elements like [1, 2, [3, 4]] work correctly"""
+            if isinstance(obj, (int, float, str, bytes, bool, type(None))):
+                return obj
+            elif isinstance(obj, (list, tuple)):
+                return tuple(to_hashable(item) for item in obj)
+            elif isinstance(obj, dict):
+                return tuple(sorted((k, to_hashable(v)) for k, v in obj.items()))
+            elif isinstance(obj, set):
+                return tuple(sorted(to_hashable(item) for item in obj))
+            else:
+                try:
+                    hash(obj)
                     return obj
-                elif isinstance(obj, (list, tuple)):
-                    return tuple(to_hashable(item) for item in obj)
-                elif isinstance(obj, dict):
-                    return tuple(sorted((k, to_hashable(v)) for k, v in obj.items()))
-                elif isinstance(obj, set):
-                    return tuple(sorted(to_hashable(item) for item in obj))
-                else:
-                    try:
-                        hash(obj)
-                        return obj
-                    except TypeError:
-                        # for other non-hashable objects, use repr to convert them to a string
-                        return repr(obj)
-        
+                except TypeError:
+                    # for other non-hashable objects, use repr to convert them to a string
+                    return repr(obj)
+
         cache_dict: Dict[Any, Any] = {}
-        
+
         @wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
             sig = inspect.signature(func)
             bound_args = sig.bind(*args, **kwargs)
             bound_args.apply_defaults()
-            
+
             hashable_args = to_hashable(bound_args.args)
             hashable_kwargs = to_hashable(bound_args.kwargs)
 
@@ -54,16 +56,16 @@ def cache(maxsize: Optional[int] = None) -> Callable:
 
             if cache_key in cache_dict:
                 return cache_dict[cache_key]
-            
+
             if len(cache_dict) == maxsize:
-               raise ValueError(f"Cache full: {maxsize} items max")
-            
+                raise ValueError(f"Cache full: {maxsize} items max")
+
             result = func(*args, **kwargs)
             cache_dict[cache_key] = result
             return result
-        
-        setattr(wrapper, 'cache_dict', cache_dict)
-        
+
+        setattr(wrapper, "cache_dict", cache_dict)
+
         return wrapper
-    
+
     return decorator

--- a/project/Task3/cache.py
+++ b/project/Task3/cache.py
@@ -1,4 +1,4 @@
-from typing import Callable, Any, Dict, Optional
+from typing import Callable, Any, Dict, Optional, List
 import inspect
 
 
@@ -40,7 +40,7 @@ def cache(maxsize: Optional[int] = None) -> Callable:
                     return repr(obj)
 
         cache_dict: Dict[Any, Any] = {}
-        keys: list[Any] = []
+        keys: List[Any] = []
 
         def wrapper(*args: Any, **kwargs: Any) -> Any:
 

--- a/project/Task3/cache.py
+++ b/project/Task3/cache.py
@@ -1,5 +1,4 @@
 from typing import Callable, Any, Dict, Optional
-from functools import wraps
 import inspect
 
 
@@ -24,7 +23,7 @@ def cache(maxsize: Optional[int] = None) -> Callable:
 
         def to_hashable(obj: Any) -> Any:
             """We use recursion to make elements like [1, 2, [3, 4]] work correctly"""
-            if isinstance(obj, (int, float, str, bytes, bool, type(None))):
+            if isinstance(obj, (int, float, str, bool, type(None))):
                 return obj
             elif isinstance(obj, (list, tuple)):
                 return tuple(to_hashable(item) for item in obj)
@@ -42,7 +41,6 @@ def cache(maxsize: Optional[int] = None) -> Callable:
 
         cache_dict: Dict[Any, Any] = {}
 
-        @wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:
             sig = inspect.signature(func)
             bound_args = sig.bind(*args, **kwargs)

--- a/project/Task3/cache.py
+++ b/project/Task3/cache.py
@@ -32,12 +32,7 @@ def cache(maxsize: Optional[int] = None) -> Callable:
             elif isinstance(obj, set):
                 return tuple(sorted(to_hashable(item) for item in obj))
             else:
-                try:
-                    hash(obj)  # outputs a number
-                    return obj
-                except TypeError:
-                    # for other non-hashable objects, use repr to convert them to a string
-                    return repr(obj)
+                return repr(obj)
 
         cache_dict: Dict[Any, Any] = {}
         keys: List[Any] = []

--- a/project/Task3/cache.py
+++ b/project/Task3/cache.py
@@ -22,7 +22,6 @@ def cache(maxsize: Optional[int] = None) -> Callable:
         if maxsize is None:
             return func
 
-        # Привдим нехэшируемые типы объектов к хэшируемым
         def to_hashable(obj: Any) -> Any:
             """We use recursion to make elements like [1, 2, [3, 4]] work correctly"""
             if isinstance(obj, (int, float, str, bytes, bool, type(None))):

--- a/project/Task3/cache.py
+++ b/project/Task3/cache.py
@@ -33,35 +33,37 @@ def cache(maxsize: Optional[int] = None) -> Callable:
                 return tuple(sorted(to_hashable(item) for item in obj))
             else:
                 try:
-                    hash(obj)
+                    hash(obj)  # outputs a number
                     return obj
                 except TypeError:
                     # for other non-hashable objects, use repr to convert them to a string
                     return repr(obj)
 
         cache_dict: Dict[Any, Any] = {}
+        keys: list[Any] = []
 
         def wrapper(*args: Any, **kwargs: Any) -> Any:
-            sig = inspect.signature(func)
-            bound_args = sig.bind(*args, **kwargs)
-            bound_args.apply_defaults()
 
-            hashable_args = to_hashable(bound_args.args)
-            hashable_kwargs = to_hashable(bound_args.kwargs)
+            hashable_args = to_hashable(args)
+            hashable_kwargs = to_hashable(kwargs)
 
             cache_key = (func.__name__, hashable_args, hashable_kwargs)
+            keys.append((func.__name__, hashable_args, hashable_kwargs))
 
             if cache_key in cache_dict:
                 return cache_dict[cache_key]
 
             if len(cache_dict) == maxsize:
-                raise ValueError(f"Cache full: {maxsize} items max")
+
+                oldest_key = keys.pop(0)  # deleting the very first key
+                del cache_dict[oldest_key]  # deleting the very first function call
 
             result = func(*args, **kwargs)
             cache_dict[cache_key] = result
             return result
 
         setattr(wrapper, "cache_dict", cache_dict)
+        setattr(wrapper, "keys", keys)
 
         return wrapper
 

--- a/project/Task3/smart_args.py
+++ b/project/Task3/smart_args.py
@@ -1,6 +1,5 @@
 import copy
 import inspect
-from functools import wraps
 
 
 class Evaluated:
@@ -52,7 +51,6 @@ def smart_args(func):
                 param.kind == param.KEYWORD_ONLY
             ), f"The '{param_name}' argument with {type(param.default).__name__} must be keyword-only (use * for separation)"
 
-    @wraps(func)  # to save metadata such as name, etc.
     def wrapper(*args, **kwargs):
         bound_args = signature.bind(
             *args, **kwargs

--- a/project/Task3/smart_args.py
+++ b/project/Task3/smart_args.py
@@ -54,16 +54,14 @@ def smart_args(func: Callable) -> Any:
         bound_args.apply_defaults()  # takes arguments that were not passed and are given by default and substitutes the default value for the parameter value
 
         for param_name, param in signature.parameters.items():
+            default_value = param.default
 
             # Evaluated Processing
-            if param_name not in kwargs and param.default is not param.empty:
-                default_value = param.default
-
-                if isinstance(default_value, Evaluated):
-                    bound_args.arguments[param_name] = default_value.func()
+            if isinstance(default_value, Evaluated) and param_name not in kwargs:
+                bound_args.arguments[param_name] = default_value.func()
 
             # Isolated Processing
-            if param_name in bound_args.arguments and isinstance(
+            if isinstance(
                 param.default, Isolated
             ):
 

--- a/project/Task3/smart_args.py
+++ b/project/Task3/smart_args.py
@@ -7,7 +7,7 @@ class Evaluated:
     def __init__(self, func: Callable) -> None:
 
         if isinstance(func, Isolated):
-            raise KeyError("no need to combine Isolated and Evaluated")
+            raise TypeError("no need to combine Isolated and Evaluated")
 
         self.func = func
 
@@ -16,7 +16,7 @@ class Isolated:
     def __init__(self, obj=None) -> None:
 
         if isinstance(obj, Evaluated):
-            raise KeyError("no need to combine Isolated and Evaluated")
+            raise TypeError("no need to combine Isolated and Evaluated")
         self.obj = obj
 
 

--- a/project/Task3/smart_args.py
+++ b/project/Task3/smart_args.py
@@ -1,6 +1,6 @@
 import copy
 import inspect
-from typing import Callable
+from typing import Callable, Any
 
 
 class Evaluated:
@@ -20,7 +20,7 @@ class Isolated:
         self.obj = obj
 
 
-def smart_args(func):
+def smart_args(func: Callable):
     """
     A smart decorator for handling function arguments with Isolated and Evaluated.
 
@@ -47,7 +47,7 @@ def smart_args(func):
                 param.kind == param.KEYWORD_ONLY
             ), f"The '{param_name}' argument with {type(param.default).__name__} must be keyword-only (use * for separation)"
 
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: Any, **kwargs: Any):
         bound_args = signature.bind(
             *args, **kwargs
         )  # substitutes the arguments that are passed to the function

--- a/project/Task3/smart_args.py
+++ b/project/Task3/smart_args.py
@@ -20,7 +20,7 @@ class Isolated:
         self.obj = obj
 
 
-def smart_args(func: Callable):
+def smart_args(func: Callable) -> Any:
     """
     A smart decorator for handling function arguments with Isolated and Evaluated.
 
@@ -47,7 +47,7 @@ def smart_args(func: Callable):
                 param.kind == param.KEYWORD_ONLY
             ), f"The '{param_name}' argument with {type(param.default).__name__} must be keyword-only (use * for separation)"
 
-    def wrapper(*args: Any, **kwargs: Any):
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
         bound_args = signature.bind(
             *args, **kwargs
         )  # substitutes the arguments that are passed to the function

--- a/project/Task3/smart_args.py
+++ b/project/Task3/smart_args.py
@@ -2,75 +2,86 @@ import copy
 import inspect
 from functools import wraps
 
+
 class Evaluated:
     def __init__(self, func):
         self.func = func
 
+
 class Isolated:
     pass
+
 
 def smart_args(func):
     """
     A smart decorator for handling function arguments with Isolated and Evaluated.
- 
+
     Adds special logic for arguments with default values:
         Evaluated: calculates the value each time the function is called
         Isolated: creates a deep copy of the passed value
- 
+
     Arguments:
         func: The function
- 
+
     Returns:
         The function with smart argument handling
- 
+
     AssertionError: If Isolated and Evaluated are used together
     AssertionError: If Isolated/Evaluated arguments are not keyword-only
     ValueError: If no value is passed for the Isolated argument
     """
-    signature = inspect.signature(func) # information about function parameters
+    signature = inspect.signature(func)  # information about function parameters
 
     has_isolated = False
     has_evaluated = False
-    
+
     for param_name, param in signature.parameters.items():
         if isinstance(param.default, Isolated):
             has_isolated = True
         elif isinstance(param.default, Evaluated):
             has_evaluated = True
-    
-    assert not (has_isolated and has_evaluated), "Isolated and Evaluated cannot be used together in the same function"
+
+    assert not (
+        has_isolated and has_evaluated
+    ), "Isolated and Evaluated cannot be used together in the same function"
 
     # It is necessary that ONLY named ones are transmitted
     for param_name, param in signature.parameters.items():
         if isinstance(param.default, (Isolated, Evaluated)):
-            assert param.kind == param.KEYWORD_ONLY, f"The '{param_name}' argument with {type(param.default).__name__} must be keyword-only (use * for separation)"
-   
-    @wraps(func) # to save metadata such as name, etc.
+            assert (
+                param.kind == param.KEYWORD_ONLY
+            ), f"The '{param_name}' argument with {type(param.default).__name__} must be keyword-only (use * for separation)"
+
+    @wraps(func)  # to save metadata such as name, etc.
     def wrapper(*args, **kwargs):
-        bound_args = signature.bind(*args, **kwargs) # substitutes the arguments that are passed to the function
-        bound_args.apply_defaults() # takes arguments that were not passed and are given by default and substitutes the default value for the parameter value
-        
+        bound_args = signature.bind(
+            *args, **kwargs
+        )  # substitutes the arguments that are passed to the function
+        bound_args.apply_defaults()  # takes arguments that were not passed and are given by default and substitutes the default value for the parameter value
+
         for param_name, param in signature.parameters.items():
-            
+
             # Evaluated Processing
             if param_name not in kwargs and param.default is not param.empty:
                 default_value = param.default
-                
+
                 if isinstance(default_value, Evaluated):
                     bound_args.arguments[param_name] = default_value.func()
-            
+
             # Isolated Processing
-            if (param_name in bound_args.arguments and 
-                isinstance(param.default, Isolated)):
+            if param_name in bound_args.arguments and isinstance(
+                param.default, Isolated
+            ):
 
                 if param_name not in kwargs:
-                    raise ValueError(f"The argument {param_name} with Isolated() must be passed a value")
-                
+                    raise ValueError(
+                        f"The argument {param_name} with Isolated() must be passed a value"
+                    )
+
                 original_value = bound_args.arguments[param_name]
                 copied_value = copy.deepcopy(original_value)
                 bound_args.arguments[param_name] = copied_value
-        
+
         return func(*bound_args.args, **bound_args.kwargs)
-    
+
     return wrapper
- 

--- a/project/Task3/smart_args.py
+++ b/project/Task3/smart_args.py
@@ -1,14 +1,23 @@
 import copy
 import inspect
+from typing import Callable
 
 
 class Evaluated:
-    def __init__(self, func):
+    def __init__(self, func: Callable) -> None:
+
+        if isinstance(func, Isolated):
+            raise KeyError("no need to combine Isolated and Evaluated")
+
         self.func = func
 
 
 class Isolated:
-    pass
+    def __init__(self, obj=None) -> None:
+
+        if isinstance(obj, Evaluated):
+            raise KeyError("no need to combine Isolated and Evaluated")
+        self.obj = obj
 
 
 def smart_args(func):
@@ -30,19 +39,6 @@ def smart_args(func):
     ValueError: If no value is passed for the Isolated argument
     """
     signature = inspect.signature(func)  # information about function parameters
-
-    has_isolated = False
-    has_evaluated = False
-
-    for param_name, param in signature.parameters.items():
-        if isinstance(param.default, Isolated):
-            has_isolated = True
-        elif isinstance(param.default, Evaluated):
-            has_evaluated = True
-
-    assert not (
-        has_isolated and has_evaluated
-    ), "Isolated and Evaluated cannot be used together in the same function"
 
     # It is necessary that ONLY named ones are transmitted
     for param_name, param in signature.parameters.items():

--- a/project/Task3/smart_args.py
+++ b/project/Task3/smart_args.py
@@ -1,0 +1,76 @@
+import copy
+import inspect
+from functools import wraps
+
+class Evaluated:
+    def __init__(self, func):
+        self.func = func
+
+class Isolated:
+    pass
+
+def smart_args(func):
+    """
+    A smart decorator for handling function arguments with Isolated and Evaluated.
+ 
+    Adds special logic for arguments with default values:
+        Evaluated: calculates the value each time the function is called
+        Isolated: creates a deep copy of the passed value
+ 
+    Arguments:
+        func: The function
+ 
+    Returns:
+        The function with smart argument handling
+ 
+    AssertionError: If Isolated and Evaluated are used together
+    AssertionError: If Isolated/Evaluated arguments are not keyword-only
+    ValueError: If no value is passed for the Isolated argument
+    """
+    signature = inspect.signature(func) # information about function parameters
+
+    has_isolated = False
+    has_evaluated = False
+    
+    for param_name, param in signature.parameters.items():
+        if isinstance(param.default, Isolated):
+            has_isolated = True
+        elif isinstance(param.default, Evaluated):
+            has_evaluated = True
+    
+    assert not (has_isolated and has_evaluated), "Isolated and Evaluated cannot be used together in the same function"
+
+    # It is necessary that ONLY named ones are transmitted
+    for param_name, param in signature.parameters.items():
+        if isinstance(param.default, (Isolated, Evaluated)):
+            assert param.kind == param.KEYWORD_ONLY, f"The '{param_name}' argument with {type(param.default).__name__} must be keyword-only (use * for separation)"
+   
+    @wraps(func) # to save metadata such as name, etc.
+    def wrapper(*args, **kwargs):
+        bound_args = signature.bind(*args, **kwargs) # substitutes the arguments that are passed to the function
+        bound_args.apply_defaults() # takes arguments that were not passed and are given by default and substitutes the default value for the parameter value
+        
+        for param_name, param in signature.parameters.items():
+            
+            # Evaluated Processing
+            if param_name not in kwargs and param.default is not param.empty:
+                default_value = param.default
+                
+                if isinstance(default_value, Evaluated):
+                    bound_args.arguments[param_name] = default_value.func()
+            
+            # Isolated Processing
+            if (param_name in bound_args.arguments and 
+                isinstance(param.default, Isolated)):
+
+                if param_name not in kwargs:
+                    raise ValueError(f"The argument {param_name} with Isolated() must be passed a value")
+                
+                original_value = bound_args.arguments[param_name]
+                copied_value = copy.deepcopy(original_value)
+                bound_args.arguments[param_name] = copied_value
+        
+        return func(*bound_args.args, **bound_args.kwargs)
+    
+    return wrapper
+ 

--- a/project/Task3/smart_args.py
+++ b/project/Task3/smart_args.py
@@ -61,7 +61,7 @@ def smart_args(func: Callable) -> Any:
                 bound_args.arguments[param_name] = default_value.func()
 
             # Isolated Processing
-            if isinstance(param.default, Isolated):
+            if isinstance(default_value, Isolated):
 
                 if param_name not in kwargs:
                     raise ValueError(

--- a/project/Task3/smart_args.py
+++ b/project/Task3/smart_args.py
@@ -61,9 +61,7 @@ def smart_args(func: Callable) -> Any:
                 bound_args.arguments[param_name] = default_value.func()
 
             # Isolated Processing
-            if isinstance(
-                param.default, Isolated
-            ):
+            if isinstance(param.default, Isolated):
 
                 if param_name not in kwargs:
                     raise ValueError(

--- a/project/Task3/un_curry_explicit.py
+++ b/project/Task3/un_curry_explicit.py
@@ -24,15 +24,22 @@ def curry_explicit(function: Callable[..., Any], arity: int = 0) -> Callable[...
 
         return curried_zero
 
-    def curried(*args: Any) -> Any:
-        if len(args) >= arity:
-            return function(*args[:arity])  # unnecessary arguments are ignored.
-        else:
+    def curried(first_arg: Any) -> Any:
+        args: tuple[Any, ...] = (first_arg,)
 
-            def next_curried(*next_args: Any) -> Any:
-                return curried(*(args + next_args))
+        if len(args) == arity:  # verification for arity = 1
+            return function(*args)
 
-            return next_curried
+        def next_curried(next_arg: Any) -> Any:
+            nonlocal args
+            args += (next_arg,)
+
+            if len(args) == arity:
+                return function(*args)
+            else:
+                return next_curried
+
+        return next_curried
 
     return curried
 

--- a/project/Task3/un_curry_explicit.py
+++ b/project/Task3/un_curry_explicit.py
@@ -1,0 +1,67 @@
+from typing import Callable, Any
+
+def curry_explicit(function: Callable[..., Any], arity : int = 0) -> Callable[..., Any]:
+    """
+    Converts a function to a curried version.
+ 
+    Arguments:
+        function: The function to curry
+        arity: How many arguments the original function should take
+ 
+    Returns:
+        The curried version of the function
+ 
+    ValueError: If arity is a negative number
+    """
+    if arity < 0:
+        raise ValueError("Arity cannot be negative")
+    
+    if arity == 0:
+        def curried_zero() -> Any:
+            return function()
+        return curried_zero
+    
+    def curried(*args: Any) -> Any:
+        if len(args) >= arity:
+            return function(*args[:arity])  # unnecessary arguments are ignored.
+        else:
+
+            def next_curried(*next_args: Any) -> Any:
+                return curried(*(args + next_args))
+            return next_curried
+    
+    return curried
+
+def uncurry_explicit(function: Callable[..., Any], arity : int = 0) -> Callable[..., Any]:
+    """
+    Makes a curried function a regular function.
+ 
+    Args:
+        function: A curried function 
+        arity: The number of arguments
+ 
+    Returns:
+        A function
+ 
+    ValueError: If arity < 0 or the number of arguments is incorrect
+    TypeError: If currying is violated
+    """
+    if arity < 0:
+        raise ValueError("Arity cannot be negative")
+    
+    if arity == 0:
+
+        def uncurried_zero() -> Any:
+            return function()
+        return uncurried_zero
+    
+    def uncurried(*args: Any) -> Any:
+        if len(args) != arity:
+            raise ValueError(f"Expected {arity} arguments, but received {len(args)}")
+        
+        result = function
+        for arg in args:
+            result = result(arg)
+        return result
+    
+    return uncurried

--- a/project/Task3/un_curry_explicit.py
+++ b/project/Task3/un_curry_explicit.py
@@ -1,26 +1,29 @@
 from typing import Callable, Any
 
-def curry_explicit(function: Callable[..., Any], arity : int = 0) -> Callable[..., Any]:
+
+def curry_explicit(function: Callable[..., Any], arity: int = 0) -> Callable[..., Any]:
     """
     Converts a function to a curried version.
- 
+
     Arguments:
         function: The function to curry
         arity: How many arguments the original function should take
- 
+
     Returns:
         The curried version of the function
- 
+
     ValueError: If arity is a negative number
     """
     if arity < 0:
         raise ValueError("Arity cannot be negative")
-    
+
     if arity == 0:
+
         def curried_zero() -> Any:
             return function()
+
         return curried_zero
-    
+
     def curried(*args: Any) -> Any:
         if len(args) >= arity:
             return function(*args[:arity])  # unnecessary arguments are ignored.
@@ -28,40 +31,45 @@ def curry_explicit(function: Callable[..., Any], arity : int = 0) -> Callable[..
 
             def next_curried(*next_args: Any) -> Any:
                 return curried(*(args + next_args))
+
             return next_curried
-    
+
     return curried
 
-def uncurry_explicit(function: Callable[..., Any], arity : int = 0) -> Callable[..., Any]:
+
+def uncurry_explicit(
+    function: Callable[..., Any], arity: int = 0
+) -> Callable[..., Any]:
     """
     Makes a curried function a regular function.
- 
+
     Args:
-        function: A curried function 
+        function: A curried function
         arity: The number of arguments
- 
+
     Returns:
         A function
- 
+
     ValueError: If arity < 0 or the number of arguments is incorrect
     TypeError: If currying is violated
     """
     if arity < 0:
         raise ValueError("Arity cannot be negative")
-    
+
     if arity == 0:
 
         def uncurried_zero() -> Any:
             return function()
+
         return uncurried_zero
-    
+
     def uncurried(*args: Any) -> Any:
         if len(args) != arity:
             raise ValueError(f"Expected {arity} arguments, but received {len(args)}")
-        
+
         result = function
         for arg in args:
             result = result(arg)
         return result
-    
+
     return uncurried

--- a/project/Task3/un_curry_explicit.py
+++ b/project/Task3/un_curry_explicit.py
@@ -1,4 +1,4 @@
-from typing import Callable, Any
+from typing import Callable, Any, Tuple
 
 
 def curry_explicit(function: Callable[..., Any], arity: int = 0) -> Callable[..., Any]:
@@ -25,7 +25,7 @@ def curry_explicit(function: Callable[..., Any], arity: int = 0) -> Callable[...
         return curried_zero
 
     def curried(first_arg: Any) -> Any:
-        args: tuple[Any, ...] = (first_arg,)
+        args: Tuple[Any, ...] = (first_arg,)
 
         if len(args) == arity:  # verification for arity = 1
             return function(*args)

--- a/tests/tests_Task3/test_(un)curry_excplicit.py
+++ b/tests/tests_Task3/test_(un)curry_excplicit.py
@@ -19,9 +19,10 @@ def test_curry_explicit_error():
 
     with pytest.raises(TypeError):
         curried(1, 2)(3)
-        
+
     with pytest.raises(TypeError):
-        curried(1)(2,3)
+        curried(1)(2, 3)
+
 
 def test_curry_explicit_zero_arity():
     def func():

--- a/tests/tests_Task3/test_(un)curry_excplicit.py
+++ b/tests/tests_Task3/test_(un)curry_excplicit.py
@@ -5,79 +5,89 @@ from project.Task3.un_curry_explicit import *
 def test_curry_explicit_basic():
     def func(a, b, c):
         return f"({a}, {b}, {c})"
-    
+
     curried = curry_explicit(func, 3)
-    
+
     assert curried(1)(2)(3) == "(1, 2, 3)"
     assert curried(1, 2)(3) == "(1, 2, 3)"
     assert curried(1, 2, 3) == "(1, 2, 3)"
 
+
 def test_curry_explicit_zero_arity():
     def func():
         return "result"
-    
+
     curried = curry_explicit(func, 0)
     assert curried() == "result"
+
 
 def test_curry_explicit_negative_arity():
     with pytest.raises(ValueError):
         curry_explicit(lambda x: x, -1)
+
 
 def test_curry_explicit_with_builtin():
     curried_add = curry_explicit(lambda x, y: x + y, 2)
     assert curried_add(5)(3) == 8
     assert curried_add(10)(20) == 30
 
+
 def test_curry_explicit_variable_arity_ignored():
     def func(a, b, c):
         return a + b + c
-    
+
     curried = curry_explicit(func, 3)
-    
+
     assert curried(1, 2, 3, 4, 5) == 6
     assert curried(1)(2, 3, 4, 5) == 6
+
 
 def test_curry_explicit_multiple_args_at_once():
     def func(a, b, c, d):
         return f"{a} {b} {c} {d}"
-    
+
     curried = curry_explicit(func, 4)
-    
+
     assert curried(1)(2, 3)(4) == "1 2 3 4"
     assert curried(1, 2)(3, 4) == "1 2 3 4"
     assert curried(1, 2, 3)(4) == "1 2 3 4"
 
+
 def test_uncurry_explicit_basic():
     def func(a, b, c):
         return a + b + c
-    
+
     curried = curry_explicit(func, 3)
     uncurried = uncurry_explicit(curried, 3)
-    
+
     assert uncurried(1, 2, 3) == 6
+
 
 def test_uncurry_explicit_zero_arity():
     def func():
         return "zero"
-    
+
     curried = curry_explicit(func, 0)
     uncurried = uncurry_explicit(curried, 0)
-    
+
     assert uncurried() == "zero"
+
 
 def test_uncurry_explicit_wrong_args_count():
     curried = curry_explicit(lambda x, y: x + y, 2)
     uncurried = uncurry_explicit(curried, 2)
-    
+
     with pytest.raises(ValueError):
         uncurried(1, 2, 3)
+
 
 def test_uncurry_explicit_negative_arity():
     with pytest.raises(ValueError):
         uncurry_explicit(lambda x: x, -1)
 
+
 def test_uncurry_explicit_with_builtin():
     curried = curry_explicit(lambda x, y, z: x * y * z, 3)
     uncurried = uncurry_explicit(curried, 3)
-    
+
     assert uncurried(2, 3, 4) == 24

--- a/tests/tests_Task3/test_(un)curry_excplicit.py
+++ b/tests/tests_Task3/test_(un)curry_excplicit.py
@@ -1,0 +1,83 @@
+import pytest
+from project.Task3.un_curry_explicit import *
+
+
+def test_curry_explicit_basic():
+    def func(a, b, c):
+        return f"({a}, {b}, {c})"
+    
+    curried = curry_explicit(func, 3)
+    
+    assert curried(1)(2)(3) == "(1, 2, 3)"
+    assert curried(1, 2)(3) == "(1, 2, 3)"
+    assert curried(1, 2, 3) == "(1, 2, 3)"
+
+def test_curry_explicit_zero_arity():
+    def func():
+        return "result"
+    
+    curried = curry_explicit(func, 0)
+    assert curried() == "result"
+
+def test_curry_explicit_negative_arity():
+    with pytest.raises(ValueError):
+        curry_explicit(lambda x: x, -1)
+
+def test_curry_explicit_with_builtin():
+    curried_add = curry_explicit(lambda x, y: x + y, 2)
+    assert curried_add(5)(3) == 8
+    assert curried_add(10)(20) == 30
+
+def test_curry_explicit_variable_arity_ignored():
+    def func(a, b, c):
+        return a + b + c
+    
+    curried = curry_explicit(func, 3)
+    
+    assert curried(1, 2, 3, 4, 5) == 6
+    assert curried(1)(2, 3, 4, 5) == 6
+
+def test_curry_explicit_multiple_args_at_once():
+    def func(a, b, c, d):
+        return f"{a} {b} {c} {d}"
+    
+    curried = curry_explicit(func, 4)
+    
+    assert curried(1)(2, 3)(4) == "1 2 3 4"
+    assert curried(1, 2)(3, 4) == "1 2 3 4"
+    assert curried(1, 2, 3)(4) == "1 2 3 4"
+
+def test_uncurry_explicit_basic():
+    def func(a, b, c):
+        return a + b + c
+    
+    curried = curry_explicit(func, 3)
+    uncurried = uncurry_explicit(curried, 3)
+    
+    assert uncurried(1, 2, 3) == 6
+
+def test_uncurry_explicit_zero_arity():
+    def func():
+        return "zero"
+    
+    curried = curry_explicit(func, 0)
+    uncurried = uncurry_explicit(curried, 0)
+    
+    assert uncurried() == "zero"
+
+def test_uncurry_explicit_wrong_args_count():
+    curried = curry_explicit(lambda x, y: x + y, 2)
+    uncurried = uncurry_explicit(curried, 2)
+    
+    with pytest.raises(ValueError):
+        uncurried(1, 2, 3)
+
+def test_uncurry_explicit_negative_arity():
+    with pytest.raises(ValueError):
+        uncurry_explicit(lambda x: x, -1)
+
+def test_uncurry_explicit_with_builtin():
+    curried = curry_explicit(lambda x, y, z: x * y * z, 3)
+    uncurried = uncurry_explicit(curried, 3)
+    
+    assert uncurried(2, 3, 4) == 24

--- a/tests/tests_Task3/test_(un)curry_excplicit.py
+++ b/tests/tests_Task3/test_(un)curry_excplicit.py
@@ -9,8 +9,16 @@ def test_curry_explicit_basic():
     curried = curry_explicit(func, 3)
 
     assert curried(1)(2)(3) == "(1, 2, 3)"
-    assert curried(1, 2)(3) == "(1, 2, 3)"
-    assert curried(1, 2, 3) == "(1, 2, 3)"
+
+
+def test_curry_explicit_error():
+    def func(a, b, c):
+        return f"({a}, {b}, {c})"
+
+    curried = curry_explicit(func, 3)
+
+    with pytest.raises(TypeError):
+        curried(1, 2)(3)
 
 
 def test_curry_explicit_zero_arity():
@@ -32,25 +40,37 @@ def test_curry_explicit_with_builtin():
     assert curried_add(10)(20) == 30
 
 
-def test_curry_explicit_variable_arity_ignored():
-    def func(a, b, c):
-        return a + b + c
+def test_curry_with_python_function():
+    curried_max = curry_explicit(max, 2)
 
-    curried = curry_explicit(func, 3)
+    result = curried_max(5)(10)
+    assert result == 10
+    result = curried_max(30)(5)
+    assert result == 30
 
-    assert curried(1, 2, 3, 4, 5) == 6
-    assert curried(1)(2, 3, 4, 5) == 6
+    curried_min = curry_explicit(min, 3)
+
+    result = curried_min(5)(10)(3)
+    assert result == 3
+
+    curried_print = curry_explicit(print, 1)
+
+    curried_print("hello")
+
+    curried_len = curry_explicit(len, 1)
+
+    result = curried_len([1, 2, 3])
+    assert result == 3
 
 
-def test_curry_explicit_multiple_args_at_once():
-    def func(a, b, c, d):
-        return f"{a} {b} {c} {d}"
+def test_curry_variable_of_number_args():
+    def mixed_func(a, b, *args):
+        return a + b + sum(args)
 
-    curried = curry_explicit(func, 4)
+    curried_mixed = curry_explicit(mixed_func, 7)
 
-    assert curried(1)(2, 3)(4) == "1 2 3 4"
-    assert curried(1, 2)(3, 4) == "1 2 3 4"
-    assert curried(1, 2, 3)(4) == "1 2 3 4"
+    result = curried_mixed(5)(10)(5)(4)(3)(2)(5)
+    assert result == 34
 
 
 def test_uncurry_explicit_basic():

--- a/tests/tests_Task3/test_(un)curry_excplicit.py
+++ b/tests/tests_Task3/test_(un)curry_excplicit.py
@@ -19,7 +19,9 @@ def test_curry_explicit_error():
 
     with pytest.raises(TypeError):
         curried(1, 2)(3)
-
+        
+    with pytest.raises(TypeError):
+        curried(1)(2,3)
 
 def test_curry_explicit_zero_arity():
     def func():

--- a/tests/tests_Task3/test_cache.py
+++ b/tests/tests_Task3/test_cache.py
@@ -1,0 +1,91 @@
+import pytest
+from project.Task3.cache import cache
+
+class Test_cache:
+    
+    def test_simple_function_caching(self):
+        """Simple function caching test"""
+        @cache(maxsize=3)
+        def add(a, b):
+            return a + b
+        
+        result1 = add(2, 3)
+        assert result1 == 5
+        assert len(add.cache_dict) == 1
+        
+        result2 = add(5, 7)
+        assert result2 == 12
+        assert len(add.cache_dict) == 2
+        
+        result3 = add(2, 3)
+        assert result3 == 5
+        assert len(add.cache_dict) == 2
+    
+    def test_builting_functions(self):
+        """Test with built-in Python functions"""
+
+        cached_upper = cache(maxsize=2)(str.upper)
+        cached_len = cache(maxsize=2)(len)
+
+        result1 = cached_upper("hello")
+        result2 = cached_upper("world")
+        result3 = cached_upper("hello")
+    
+        assert result1 == "HELLO"
+        assert result2 == "WORLD"
+        assert result3 == "HELLO"
+        assert len(cached_upper.cache_dict) == 2
+
+        result4 = cached_len("hello")
+        result5 = cached_len((1, 2, 3))
+        result6 = cached_len("hello")
+    
+        assert result4 == 5
+        assert result5 == 3
+        assert result6 == 5
+        assert len(cached_len.cache_dict) == 2
+    
+    def test_unhashable_arguments(self):
+        """Test with non-hashable arguments (lists, dictionaries)"""
+        @cache(maxsize=2)
+        def process_data(data_list, config_dict):
+            return len(data_list), len(config_dict)
+    
+        result1 = process_data([1, 2, 3], {'mode': 'fast'})
+        assert result1 == (3, 1)
+        assert len(process_data.cache_dict) == 1
+    
+        result2 = process_data([4, 5], {'mode': 'slow', 'speed': 'high'})
+        assert result2 == (2, 2)
+        assert len(process_data.cache_dict) == 2
+
+    
+    def test_cache_overflow(self):
+        """Cache overflow test"""
+        @cache(maxsize=2)
+        def multiply(a, b):
+            return a * b
+        
+        multiply(2, 3)
+        multiply(4, 5)
+
+        with pytest.raises(ValueError):
+            multiply(6, 7)
+        
+        assert len(multiply.cache_dict) == 2
+    
+    def test_no_caching(self):
+        """Disable caching test (maxsize=None)"""
+        @cache(maxsize=None)
+        def subtract(a, b):
+            return a - b
+        
+        result1 = subtract(10, 3)
+        result2 = subtract(10, 3)
+        
+        assert result1 == 7
+        assert result2 == 7
+
+        # We check that the cache was not created
+        assert not hasattr(subtract, 'cache_dict')
+    

--- a/tests/tests_Task3/test_cache.py
+++ b/tests/tests_Task3/test_cache.py
@@ -1,26 +1,27 @@
 import pytest
 from project.Task3.cache import cache
 
+
 class Test_cache:
-    
     def test_simple_function_caching(self):
         """Simple function caching test"""
+
         @cache(maxsize=3)
         def add(a, b):
             return a + b
-        
+
         result1 = add(2, 3)
         assert result1 == 5
         assert len(add.cache_dict) == 1
-        
+
         result2 = add(5, 7)
         assert result2 == 12
         assert len(add.cache_dict) == 2
-        
+
         result3 = add(2, 3)
         assert result3 == 5
         assert len(add.cache_dict) == 2
-    
+
     def test_builting_functions(self):
         """Test with built-in Python functions"""
 
@@ -30,7 +31,7 @@ class Test_cache:
         result1 = cached_upper("hello")
         result2 = cached_upper("world")
         result3 = cached_upper("hello")
-    
+
         assert result1 == "HELLO"
         assert result2 == "WORLD"
         assert result3 == "HELLO"
@@ -39,53 +40,54 @@ class Test_cache:
         result4 = cached_len("hello")
         result5 = cached_len((1, 2, 3))
         result6 = cached_len("hello")
-    
+
         assert result4 == 5
         assert result5 == 3
         assert result6 == 5
         assert len(cached_len.cache_dict) == 2
-    
+
     def test_unhashable_arguments(self):
         """Test with non-hashable arguments (lists, dictionaries)"""
+
         @cache(maxsize=2)
         def process_data(data_list, config_dict):
             return len(data_list), len(config_dict)
-    
-        result1 = process_data([1, 2, 3], {'mode': 'fast'})
+
+        result1 = process_data([1, 2, 3], {"mode": "fast"})
         assert result1 == (3, 1)
         assert len(process_data.cache_dict) == 1
-    
-        result2 = process_data([4, 5], {'mode': 'slow', 'speed': 'high'})
+
+        result2 = process_data([4, 5], {"mode": "slow", "speed": "high"})
         assert result2 == (2, 2)
         assert len(process_data.cache_dict) == 2
 
-    
     def test_cache_overflow(self):
         """Cache overflow test"""
+
         @cache(maxsize=2)
         def multiply(a, b):
             return a * b
-        
+
         multiply(2, 3)
         multiply(4, 5)
 
         with pytest.raises(ValueError):
             multiply(6, 7)
-        
+
         assert len(multiply.cache_dict) == 2
-    
+
     def test_no_caching(self):
         """Disable caching test (maxsize=None)"""
+
         @cache(maxsize=None)
         def subtract(a, b):
             return a - b
-        
+
         result1 = subtract(10, 3)
         result2 = subtract(10, 3)
-        
+
         assert result1 == 7
         assert result2 == 7
 
         # We check that the cache was not created
-        assert not hasattr(subtract, 'cache_dict')
-    
+        assert not hasattr(subtract, "cache_dict")

--- a/tests/tests_Task3/test_cache.py
+++ b/tests/tests_Task3/test_cache.py
@@ -71,8 +71,18 @@ class Test_cache:
         multiply(2, 3)
         multiply(4, 5)
 
-        with pytest.raises(ValueError):
-            multiply(6, 7)
+        keys_before_1 = multiply.keys[0]
+        keys_before_2 = multiply.keys[1]
+
+        assert len(multiply.cache_dict) == 2
+
+        multiply(6, 7)
+
+        keys_after_1 = multiply.keys[0]
+        keys_after_2 = multiply.keys[1]
+
+        assert keys_after_1 == keys_before_2
+        assert not keys_before_1 == keys_after_1
 
         assert len(multiply.cache_dict) == 2
 

--- a/tests/tests_Task3/test_smart_args.py
+++ b/tests/tests_Task3/test_smart_args.py
@@ -49,7 +49,7 @@ def test_isolated_basic():
     result = test_func(data=original_list)
 
     assert result == [1, 2, 3, 4]
-    assert original_list == [1, 2, 3]  # Оригинал не изменился
+    assert original_list == [1, 2, 3]
 
 
 def test_isolated_without_value():

--- a/tests/tests_Task3/test_smart_args.py
+++ b/tests/tests_Task3/test_smart_args.py
@@ -61,12 +61,37 @@ def test_isolated_without_value():
         test_func()
 
 
-def test_isolated_and_evaluated_together_error():
-    with pytest.raises(AssertionError):
+def test_isolated_and_evaluated_together():
 
-        @smart_args
-        def invalid_func(*, x=Isolated(), y=Evaluated(get_counter)):
-            return x, y
+    original_list = [1, 2, 3]
+
+    @smart_args
+    def func(*, data=Isolated(), y=Evaluated(get_counter)):
+        data.append(4)
+        return data, y
+
+    result_1, result_2 = func(data=original_list)
+    assert result_1 == [1, 2, 3, 4]
+    assert original_list == [1, 2, 3]
+    assert result_2 == 1
+    result_1, result_2 = func(data=original_list, y=100)
+
+    assert result_1 == [1, 2, 3, 4]
+    assert original_list == [1, 2, 3]
+    assert result_2 == 100
+
+
+def test_evaluated_isolated_error():
+
+    with pytest.raises(KeyError):
+
+        def func(*, x=Evaluated(Isolated())):
+            return x
+
+    with pytest.raises(KeyError):
+
+        def func(*, x=Isolated(Evaluated(lambda: 42))):
+            return x
 
 
 def test_non_keyword_only_error():

--- a/tests/tests_Task3/test_smart_args.py
+++ b/tests/tests_Task3/test_smart_args.py
@@ -2,71 +2,82 @@ import pytest
 from project.Task3.smart_args import *
 
 counter = 0
+
+
 def get_counter():
     global counter
     counter += 1
     return counter
 
+
 def test_evaluated_basic():
     global counter
     counter = 0
-    
+
     @smart_args
     def test_func(*, x=Evaluated(get_counter)):
         return x
-    
+
     result1 = test_func()
     result2 = test_func()
-    
+
     assert result1 == 1
     assert result2 == 2
+
 
 def test_evaluated_with_passed_argument():
     global counter
     counter = 0
-    
+
     @smart_args
     def test_func(*, x=Evaluated(get_counter)):
         return x
-    
+
     result = test_func(x=100)
     assert result == 100
     assert counter == 0
 
+
 def test_isolated_basic():
     original_list = [1, 2, 3]
-    
+
     @smart_args
     def test_func(*, data=Isolated()):
         data.append(4)
         return data
-    
+
     result = test_func(data=original_list)
-    
+
     assert result == [1, 2, 3, 4]
     assert original_list == [1, 2, 3]  # Оригинал не изменился
+
 
 def test_isolated_without_value():
     @smart_args
     def test_func(*, data=Isolated()):
         return data
-    
+
     with pytest.raises(ValueError):
         test_func()
 
 
 def test_isolated_and_evaluated_together_error():
     with pytest.raises(AssertionError):
+
         @smart_args
         def invalid_func(*, x=Isolated(), y=Evaluated(get_counter)):
             return x, y
 
+
 def test_non_keyword_only_error():
     with pytest.raises(AssertionError):
+
         @smart_args
         def invalid_func(x=Isolated()):
             return x
+
     with pytest.raises(AssertionError):
+
         @smart_args
         def invalid_func(x=Evaluated(get_counter)):
             return x

--- a/tests/tests_Task3/test_smart_args.py
+++ b/tests/tests_Task3/test_smart_args.py
@@ -83,12 +83,12 @@ def test_isolated_and_evaluated_together():
 
 def test_evaluated_isolated_error():
 
-    with pytest.raises(KeyError):
+    with pytest.raises(TypeError):
 
         def func(*, x=Evaluated(Isolated())):
             return x
 
-    with pytest.raises(KeyError):
+    with pytest.raises(TypeError):
 
         def func(*, x=Isolated(Evaluated(lambda: 42))):
             return x

--- a/tests/tests_Task3/test_smart_args.py
+++ b/tests/tests_Task3/test_smart_args.py
@@ -1,0 +1,72 @@
+import pytest
+from project.Task3.smart_args import *
+
+counter = 0
+def get_counter():
+    global counter
+    counter += 1
+    return counter
+
+def test_evaluated_basic():
+    global counter
+    counter = 0
+    
+    @smart_args
+    def test_func(*, x=Evaluated(get_counter)):
+        return x
+    
+    result1 = test_func()
+    result2 = test_func()
+    
+    assert result1 == 1
+    assert result2 == 2
+
+def test_evaluated_with_passed_argument():
+    global counter
+    counter = 0
+    
+    @smart_args
+    def test_func(*, x=Evaluated(get_counter)):
+        return x
+    
+    result = test_func(x=100)
+    assert result == 100
+    assert counter == 0
+
+def test_isolated_basic():
+    original_list = [1, 2, 3]
+    
+    @smart_args
+    def test_func(*, data=Isolated()):
+        data.append(4)
+        return data
+    
+    result = test_func(data=original_list)
+    
+    assert result == [1, 2, 3, 4]
+    assert original_list == [1, 2, 3]  # Оригинал не изменился
+
+def test_isolated_without_value():
+    @smart_args
+    def test_func(*, data=Isolated()):
+        return data
+    
+    with pytest.raises(ValueError):
+        test_func()
+
+
+def test_isolated_and_evaluated_together_error():
+    with pytest.raises(AssertionError):
+        @smart_args
+        def invalid_func(*, x=Isolated(), y=Evaluated(get_counter)):
+            return x, y
+
+def test_non_keyword_only_error():
+    with pytest.raises(AssertionError):
+        @smart_args
+        def invalid_func(x=Isolated()):
+            return x
+    with pytest.raises(AssertionError):
+        @smart_args
+        def invalid_func(x=Evaluated(get_counter)):
+            return x


### PR DESCRIPTION

## curry_explicit(function, arity)

- [x] **Negative arity is not possible** - throws an exception if arity < 0
- [x] **When arity is 0** - the result is a function with 0 parameters: `curry_explicit(f,0)() == f()`
- [x] **For arity 1**, it is a function of 1 parameter: `curry_explicit(f,1)(x) == f(x)`
- [x] **Arbitrary-ary functions** - curry_explicit freezes their arity
- [x] **Arity error checking** - throws an exception if the passed arguments do not match the declared arity.
- [x] **Named arguments are not supported**

## uncurry_explicit(function, arity)

- [x] **Negative arity is not possible** - throws an exception if arity < 0
- [x] **For arity 0** - a function with 0 parameters: `uncurry_explicit(f,0)() == f()`
- [x] **For arity 1** - a function with 1 parameter: `uncurry_explicit(f,1)(x) == f(x)`
- [x] **Arity error checking** - throws an exception if the passed arguments do not match the declared arity

- [x] **Result caching** - stores the results of calculations for different sets of arguments
- [x] **Decorator argument** - the number of recent results to store
- [x] **Default** - nothing is cached
- [x] **Support for arguments** - both unnamed and named

## The Evaluated class

- [x] **Accepts a function without arguments** - `Evaluated(func_without_args)`
- [x] **Calculation at the time of call** - substitutes a default value that is calculated every time it is called
- [x] **Can change state** - can change the global counter or the internal state of the class

## Isolated class

- [x] **Dummy default value** - `Isolated()`
- [x] **Argument must be passed** - requires an explicit value to be passed
- [x] **Deep copy** - creates a deep copy of the passed value

## Restrictions and checks

- [x] **Only named arguments** - support only for keyword-only arguments
- [x] **Combination prohibition** - you cannot use Isolated and Evaluated together in the same function
- [x] **Checks (assert)** - checks for:
 - [x] Combining Isolated and Evaluated in the same function
 - [x] Attempting to use for positional arguments
 - [x] Correct application of the decorator